### PR TITLE
Add Teams Exclusion based on importTeams flag

### DIFF
--- a/GithubRepoScanOrchestrator/index.js
+++ b/GithubRepoScanOrchestrator/index.js
@@ -9,7 +9,7 @@ const iHubStatus = require('../Lib/IHubStatus');
 
 function* processForLdif(context) {
 	const {
-		connectorConfiguration: { orgName, repoNamesExcludeList },
+		connectorConfiguration: { orgName, repoNamesExcludeList, flags },
 		secretsConfiguration: { ghToken },
 		ldifResultUrl,
 		progressCallbackUrl,
@@ -34,12 +34,17 @@ function* processForLdif(context) {
 
 	const partialResults = yield context.df.Task.all(output);
 
+	
 	try {
-		var teamResults = yield context.df.callActivity('GetOrgTeamsData', {
-			orgName,
-			ghToken,
-			orgRepositoriesIds: repositoriesIds
-		});
+		if (!flags.importTeams) {
+			teamResults = [];
+		} else {
+			var teamResults = yield context.df.callActivity('GetOrgTeamsData', {
+				orgName,
+				ghToken,
+				orgRepositoriesIds: repositoriesIds
+			});
+		}
 	} catch (e) {
 		context.log(e);
 		teamResults = [];
@@ -80,7 +85,8 @@ function* processForLdif(context) {
 		blobStorageSasUrl: ldifResultUrl,
 		metadata: {
 			bindingKey,
-			orgName
+			orgName,
+			flags
 		}
 	});
 }

--- a/SaveLdifToStorage/index.js
+++ b/SaveLdifToStorage/index.js
@@ -10,17 +10,18 @@ const ldifHeader = {
 
 module.exports = async function (
 	context,
-	{ partialResults, teamResults, repoIdsVisibilityMap, blobStorageSasUrl, metadata: { bindingKey, orgName } }
+	{ partialResults, teamResults, repoIdsVisibilityMap, blobStorageSasUrl, metadata: { bindingKey, orgName, flags } }
 ) {
-	let handler = new SaveLdifToStorageHandler(context, orgName);
+	let handler = new SaveLdifToStorageHandler(context, orgName, flags);
 	const contentArray = handler.handleLdifCreation(partialResults, teamResults, repoIdsVisibilityMap);
 	return await handler.uploadToBlob(handler.getFinalLdif(contentArray, bindingKey), blobStorageSasUrl);
 };
 
 class SaveLdifToStorageHandler {
-	constructor(context, orgName) {
+	constructor(context, orgName, flags) {
 		this.context = context;
 		this.orgName = orgName;
+		this.flags = flags
 	}
 
 	/**
@@ -185,7 +186,10 @@ class SaveLdifToStorageHandler {
 		return {
 			...ldifHeader,
 			customFields: {
-				orgName: this.orgName
+				orgName: this.orgName,
+				flags: {
+					...this.flags
+				}
 			},
 			...ldifContent
 		};

--- a/ihub-resources/connector-definition-australiaeast.json
+++ b/ihub-resources/connector-definition-australiaeast.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/ihub-resources/connector-definition-canadacentral.json
+++ b/ihub-resources/connector-definition-canadacentral.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/ihub-resources/connector-definition-eastus.json
+++ b/ihub-resources/connector-definition-eastus.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/ihub-resources/connector-definition-germanywestcentral.json
+++ b/ihub-resources/connector-definition-germanywestcentral.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/ihub-resources/connector-definition-test.json
+++ b/ihub-resources/connector-definition-test.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/ihub-resources/connector-definition-westeurope.json
+++ b/ihub-resources/connector-definition-westeurope.json
@@ -5,7 +5,10 @@
 	"documentationUrl": "https://docs-vsm.leanix.net/docs/github",
 	"connectorConfiguration": {
 		"orgName": "leanix",
-		"repoNamesExcludeList": []
+		"repoNamesExcludeList": [],
+		"flags": {
+			"importTeams": true
+		}
 	},
 	"secretsConfiguration": {
 		"ghToken": ""

--- a/integration-api-default-config.json
+++ b/integration-api-default-config.json
@@ -446,7 +446,7 @@
 				"processorDescription": "This inboundFactSheet creates a team FS for every team content type",
 				"type": "Team",
 				"filter": {
-					"exactType": "Team"
+					"advanced": "${header.customFields.flags.importTeams != false && content.type == 'Team'}"
 				},
 				"identifier": {
 					"external": {
@@ -521,7 +521,7 @@
 				"processorDescription": "This inboundRelation creates a relation b/w team and microservice FS",
 				"type": "relTeamToMicroservice",
 				"filter": {
-					"exactType": "Team"
+					"advanced": "${header.customFields.flags.importTeams == true && content.type == 'Team'}"
 				},
 				"from": {
 					"external": {
@@ -553,7 +553,7 @@
 				"processorDescription": "This inboundRelation creates a relation b/w team and it's parent team FS iff parent exists",
 				"type": "relToParent",
 				"filter": {
-					"advanced": "${content.type == 'Team' && content.data.parent != null }"
+					"advanced": "${header.customFields.flags.importTeams != false && content.type == 'Team' && content.data.parent != null }"
 				},
 				"from": {
 					"external": {
@@ -679,7 +679,7 @@
 				"processorName": "Add 'Github repository' Data Source tag on Microservice Factsheets",
 				"processorDescription": "Adds 'Github repository' Data Source tag on Software Artifact type FS for data source tracking",
 				"filter": {
-					"advanced": "${content.type == 'Repository' || content.type == 'Language' || content.type == 'Team'}"
+					"advanced": "${content.type == 'Repository' || content.type == 'Language' || (content.type == 'Team' && header.customFields.flags.importTeams != false)}"
 				},
 				"factSheets": {
 					"external": {


### PR DESCRIPTION
[x] Admin UI - ignore for now
[x] Internal doc - https://leanix.atlassian.net/wiki/spaces/VSM/pages/7488209582/GitHub+Repository+Integration
[x] external doc - https://docs-vsm.leanix.net/docs/github
[x] ihub connector templates

eg
```
	"connectorConfiguration": {
		"orgName": "leanix",
		"repoNamesExcludeList": [],
		"flags": {
			"importTeams": true
		}
	},
```

---
List of changes:

- Read the attribute **flags** from connector template
- Make the call to GetOrgTeamsData based on the importTeams flag
- Pass the flag importTeams in the LDIF (header section)
- Modify IAPI processor to only import Teams if the importTeams flag is not set to false