### PR TITLE
CID-528: removed gh tracking tag from del scope

### DIFF
--- a/integration-api-default-config.json
+++ b/integration-api-default-config.json
@@ -7,36 +7,6 @@
 		"processingDirection": "inbound",
 		"processingMode": "full",
 		"deletionScope": {
-			"tags": [
-				{
-					"tagScopes": [
-						{
-							"group": "Data Quality",
-							"tag": "github-tracking-disabled"
-						}
-					],
-					"scope": {
-						"ids": [],
-						"facetFilters": [
-							{
-								"keys": ["Microservice"],
-								"facetKey": "FactSheetTypes",
-								"operator": "AND"
-							},
-							{
-								"keys": ["${integration.tags.getTagId('Data Quality','github-tracking-disabled')}"],
-								"facetKey": "${integration.tags.getTagGroupId('Data Quality')}",
-								"operator": "AND"
-							},
-							{
-								"keys": ["${integration.tags.getTagId('Data Source','GitHub Repository')}"],
-								"facetKey": "${integration.tags.getTagGroupId('Data Source')}",
-								"operator": "AND"
-							}
-						]
-					}
-				}
-			],
 			"subscriptions": [
 				{
 					"subscriptionScopes": [
@@ -58,8 +28,7 @@
 				}
 			],
 			"maximumDeletionRatio": {
-				"subscriptions": 100,
-				"tags": 100
+				"subscriptions": 100
 			}
 		},
 		"processors": [


### PR DESCRIPTION
Since we are no longer adding the gh-tracking-disabled tag as part of the gh-integration, 

- we have already removed shipping this tag and tag group as part of the extension
- with this PR we want to remove the deletion scope as well, since it is erroring out in newly configured github integrations

https://leanix.atlassian.net/browse/CID-528